### PR TITLE
Begin implementing recovery from wallet.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+wallet.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,7 +1607,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.98",
- "toml 0.8.19",
+ "toml 0.8.20",
  "walkdir",
 ]
 
@@ -3410,7 +3410,11 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "namada_sdk",
+ "orion",
+ "rpassword",
+ "serde",
  "thiserror 1.0.69",
+ "toml 0.8.20",
  "zeroize",
 ]
 
@@ -5536,6 +5540,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6350,7 +6375,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint",
- "toml 0.8.19",
+ "toml 0.8.20",
  "url",
 ]
 
@@ -6663,9 +6688,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ bip0039 = "0.10.1"
 ed25519-dalek = {version = "1.0.1", default-features = false, features = ["rand", "u64_backend"]}
 hex = "0.4.3"
 namada_sdk = { git = "https://github.com/anoma/namada", rev="e74fdc71aa2ea6f192c0151f492fb770e1c0cfcb", default-features = false }
+orion = "0.16.0"
 thiserror = "1.0.30"
 zeroize = "1.8.1"
+toml = "0.8.20"
+serde = "1.0.217"
+rpassword = "7.3.1"
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # key-recovery
 
-This is a very simple utility to recover private keys from the obsolete `Namada Extension`. The inital _alpha_ version of
-the extension used a different derivation path, along with a different library for deriving private keys. This repo
-allows those keys to be recovered using a mnemonic phrase.
+This tool allows those keys to be recovered using a mnemonic phrase, or by decrypting secrets from a Namada `wallet.toml`.
+
+The inital _alpha_ version of the Namada extension used a different derivation path, along with a different library for deriving
+private keys.
 
 This work is based on the [a444534](https://github.com/anoma/namada-interface/tree/a444534f181f48a93f8ffda1ea65bc7b41d310b6/) of `namada-interface`.
 
@@ -21,18 +22,26 @@ To run the key-recoverer, simply run the following in a Linux or macOS terminal:
 cargo run
 ```
 
+**TODO**: Run `cargo run export`
+
 3. When prompted for an account to recover, enter the `alias` of the account you wish to recover, then when
    prompted, enter your password.
 
-### TODO:
+### Recovery from mnemonic using obsolete derivation
 
-Enable sub-command to run the mnemonic derivation (currently commented out in `main.rs`):
+**NOTE**: For now, uncomment the line `// cli::hdkeys::derive();`, then `cargo run`:
+
+**TODO**: Run `cargo run derive`
 
 - When prompted, enter your mnemonic
 - When prompted, enter derivation path, e.g., `m/44'/877'/0'/0/0`
 - Confirm the resulting `Address` and `Public Key` in the output, then copy the `Private Key`
 - In the current Namada Keychain, go to `Add Keys`, then choose the `Private Key` tab, and paste the key here
   - You should see the same Address & Public Key displayed here. You can now sign with this key in the current extension!
+
+### TODO:
+
+Enable sub-command to run the mnemonic derivation (currently commented out in `main.rs`):
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,38 @@
 # key-recovery
 
-This is a very simple utility to recover private keys from the obsolete `Namada Extension`.
+This is a very simple utility to recover private keys from the obsolete `Namada Extension`. The inital _alpha_ version of
+the extension used a different derivation path, along with a different library for deriving private keys. This repo
+allows those keys to be recovered using a mnemonic phrase.
 
 This work is based on the [a444534](https://github.com/anoma/namada-interface/tree/a444534f181f48a93f8ffda1ea65bc7b41d310b6/) of `namada-interface`.
 
 ## Usage
+
+**NOTE**: In the process of implementing sub-commands, one for deriving from mnemonic, one for attempting to
+recover from a `wallet.toml` file.
+
+To run the key-recoverer, simply run the following in a Linux or macOS terminal:
+
+1. Copy your `wallet.toml` to the root directory of this repo
+2. Run the following:
 
 ```bash
 # Optionally, run `cargo build` and set your path to the corresponding binary in `target/`
 cargo run
 ```
 
+3. When prompted for an account to recover, enter the `alias` of the account you wish to recover, then when
+   prompted, enter your password.
+
+### TODO:
+
+Enable sub-command to run the mnemonic derivation (currently commented out in `main.rs`):
+
 - When prompted, enter your mnemonic
 - When prompted, enter derivation path, e.g., `m/44'/877'/0'/0/0`
 - Confirm the resulting `Address` and `Public Key` in the output, then copy the `Private Key`
 - In the current Namada Keychain, go to `Add Keys`, then choose the `Private Key` tab, and paste the key here
   - You should see the same Address & Public Key displayed here. You can now sign with this key in the current extension!
-
-Derivation paths to try that could have been used in this early wallet:
-
-- `m/44'/877'/0'`
-- `m/44'/877'/0'/0/0`
-- `m/44'/877'/0'/0'/0'`
 
 ## Tests
 
@@ -30,3 +41,12 @@ To run unit test, issue the following command:
 ```bash
 cargo test
 ```
+
+## Notes
+
+- Original PR that updated derivation to match CLI: [#434](https://github.com/anoma/namada-interface/pull/434)
+  - Update Mnemonic to use `tiny-bip39` instead of `bip0039`
+  - Update HDWallet to use `slip10_ed25519` instead of `ed25519_dalek`
+- Example of original derivation: [keyring.ts](https://github.com/anoma/namada-interface/blob/d0a9da882943925d5b8f88af8a894a99d9e49a13/apps/extension/src/background/keyring/keyring.ts#L234)
+- CoinType already `877` as of this version of [chains/namada.ts](https://github.com/anoma/namada-interface/blob/d0a9da882943925d5b8f88af8a894a99d9e49a13/packages/chains/src/chains/namada.ts#L21)
+  - Default path on Mnemonic import was: `m/44'/877'/0'/0`

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -6,11 +6,9 @@ use serde::Deserialize;
 use toml::{self, Value};
 
 use crate::{
-    crypto::{
-        aead::AEAD,
-        utils::{get_input, prompt_password},
-    },
+    crypto::aead::AEAD,
     types::address,
+    utils::{get_input, prompt_password},
 };
 
 #[derive(Debug, Deserialize)]
@@ -43,7 +41,8 @@ struct Wallet {
     address_vp_types: Value,
 }
 
-pub fn import() {
+/// Export secret key from wallet.toml
+pub fn export() {
     println!("Parsing wallet.toml...");
     let filename = "wallet.toml";
 

--- a/src/cli/hdkeys.rs
+++ b/src/cli/hdkeys.rs
@@ -1,5 +1,8 @@
-use crate::crypto::{keys, mnemonic, utils};
 use crate::types::address;
+use crate::{
+    crypto::{keys, mnemonic},
+    utils,
+};
 use zeroize::Zeroize;
 
 const INPUT_ERROR: &str = "Enountered error obtaining input from user!";

--- a/src/cli/hdkeys.rs
+++ b/src/cli/hdkeys.rs
@@ -1,0 +1,42 @@
+use crate::crypto::{keys, mnemonic, utils};
+use crate::types::address;
+use zeroize::Zeroize;
+
+const INPUT_ERROR: &str = "Enountered error obtaining input from user!";
+
+pub fn derive() {
+    let mut phrase = utils::get_input("Enter mnemonic phrase:").expect(INPUT_ERROR);
+    let m = mnemonic::Mnemonic::from_phrase(&phrase);
+    phrase.zeroize();
+
+    match m {
+        Ok(m) => {
+            println!("\nMnemonic is valid, continuing...");
+            let hd_path = utils::get_input("Enter derivation path:").expect(INPUT_ERROR);
+            println!("Using path: {}\n", &hd_path);
+
+            let mut seed = m
+                .to_seed(None)
+                .expect("Conversion to seed bytes should not fail!");
+            let wallet = keys::HDWallet::new(seed.clone()).expect("Could not instantiate wallet!");
+            seed.zeroize();
+
+            let keypair = wallet.derive(hd_path).expect("Invalid path!");
+
+            let mut private_key = keypair.private().to_hex();
+            println!("Private Key: {}", &private_key);
+
+            let address_util = address::Address::new(private_key.clone());
+            private_key.zeroize();
+
+            let public_key = address_util.public();
+            let address = address_util.implicit();
+
+            println!("Address: {}", &address);
+            println!("Public Key: {}", &public_key);
+        }
+        Err(error) => {
+            panic!("\n{}\n", error);
+        }
+    }
+}

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,0 +1,97 @@
+use std::{fs, process::exit};
+use zeroize::Zeroize;
+
+// use crate::crypto::aead;
+use serde::Deserialize;
+use toml::{self, Value};
+
+use crate::crypto::{
+    aead::AEAD,
+    utils::{get_input, prompt_password},
+};
+
+#[derive(Debug, Deserialize)]
+struct Wallet {
+    #[allow(dead_code)]
+    view_keys: Value,
+
+    #[allow(dead_code)]
+    spend_keys: Value,
+
+    #[allow(dead_code)]
+    secret_keys: Value,
+
+    #[allow(dead_code)]
+    payment_addrs: Value,
+
+    #[allow(dead_code)]
+    public_keys: Value,
+
+    #[allow(dead_code)]
+    addresses: Value,
+
+    #[allow(dead_code)]
+    derivation_paths: Value,
+
+    #[allow(dead_code)]
+    pkhs: Value,
+
+    #[allow(dead_code)]
+    address_vp_types: Value,
+}
+
+pub fn import() {
+    println!("Parsing wallet.toml...");
+    let filename = "wallet.toml";
+
+    let contents = match fs::read_to_string(filename) {
+        Ok(c) => {
+            println!("Loaded contents...");
+            c
+        }
+        Err(_) => {
+            eprintln!("Could not read file `{}`", filename);
+            exit(1);
+        }
+    };
+
+    let account = get_input("\nWhich account would you like to recover? ").expect("Invalid input");
+
+    let data: Wallet = match toml::from_str(&contents) {
+        Ok(d) => d,
+        Err(err) => {
+            eprintln!("Unable to load data from `{}`: {}", filename, err);
+            exit(1);
+        }
+    };
+
+    // TODO: Better checking and error handling here:
+    if data.secret_keys[account.clone()].is_str() {
+        let entry_maybe = &data.secret_keys[account].as_str();
+
+        if let Some(entry) = entry_maybe {
+            let entry_parts = entry.split(":").collect::<Vec<&str>>();
+            let prefix = entry_parts.first().expect("Must have a prefix");
+            let secret = entry_parts.get(1).expect("Must have a key");
+
+            if prefix == &"encrypted" {
+                println!("Found encrypted secret: {}\n", &secret);
+                let mut password = prompt_password("Enter your password to decrypt: ");
+                let decoded = hex::decode(secret).expect("Hex decoding should not fail!");
+                let decrypted = AEAD::decrypt(decoded, password.clone());
+                password.zeroize();
+
+                match decrypted {
+                    Ok(value) => {
+                        println!("Recovered secret: {}", &value);
+                    }
+                    Err(err) => {
+                        println!("{}", err);
+                    }
+                }
+            } else {
+                println!("Found unencrypted secret: {}", &secret);
+            }
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,2 @@
+pub mod hdkeys;
+pub mod import;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,2 @@
+pub mod export;
 pub mod hdkeys;
-pub mod import;

--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -1,0 +1,82 @@
+use orion::{aead, kdf};
+use std::str;
+use thiserror::Error;
+
+use crate::crypto::utils::{encryption_key, encryption_salt};
+
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum DecryptionError {
+    #[error("Unexpected encryption salt")]
+    BadSalt,
+    #[error("Unable to decrypt. Is the password correct?")]
+    DecryptionError,
+}
+
+pub struct AEAD;
+
+/// A set of simple WASM-compatible AEAD (Authenticated Encryption with Additional Data) functions
+impl AEAD {
+    pub fn encrypt_from_bytes(bytes: Vec<u8>, password: String) -> Vec<u8> {
+        let bytes: &[u8] = &bytes;
+        let salt = encryption_salt();
+        let encryption_key = encryption_key(&salt, password);
+        let encrypted_keypair =
+            aead::seal(&encryption_key, bytes).expect("Encryption of data shouldn't fail");
+
+        [salt.as_ref(), &encrypted_keypair].concat()
+    }
+
+    pub fn encrypt(value: String, password: String) -> Vec<u8> {
+        let data = Vec::from(value.as_bytes());
+        AEAD::encrypt_from_bytes(data, password)
+    }
+
+    pub fn decrypt(encrypted: Vec<u8>, password: String) -> Result<String, String> {
+        let salt_len = encryption_salt().len();
+        let (raw_salt, cipher) = encrypted.split_at(salt_len);
+
+        let salt =
+            kdf::Salt::from_slice(raw_salt).map_err(|_| DecryptionError::BadSalt.to_string())?;
+
+        let encryption_key = encryption_key(&salt, password);
+
+        let decrypted_data: &[u8] = &aead::open(&encryption_key, cipher)
+            .map_err(|err| format!("{}: {:?}", &DecryptionError::DecryptionError, err))?;
+
+        let s = match str::from_utf8(decrypted_data) {
+            Ok(v) => v,
+            Err(error) => return Err(error.to_string()),
+        };
+
+        Ok(String::from(s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_decrypt_encrypted_string() {
+        let password = String::from("unhackable");
+        let message = String::from("My secret message");
+
+        let encrypted = AEAD::encrypt(message.clone(), password.clone());
+        let decrypted = AEAD::decrypt(encrypted, password).expect("Value should be decrypted");
+
+        assert_eq!(decrypted, message);
+    }
+
+    #[test]
+    fn can_decrypt_encrypted_data() {
+        let password = String::from("unhackable");
+        let message = String::from("My secret message");
+        let bytes = Vec::from(message.as_bytes());
+
+        let encrypted = AEAD::encrypt_from_bytes(bytes, password.clone());
+        let decrypted = AEAD::decrypt(encrypted, password).expect("Value should be decrypted");
+
+        assert_eq!(decrypted, message);
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,3 +1,4 @@
+pub mod aead;
 pub mod keys;
 pub mod mnemonic;
 pub mod utils;

--- a/src/crypto/utils.rs
+++ b/src/crypto/utils.rs
@@ -1,4 +1,8 @@
-use std::io::{self, Error};
+use orion::kdf;
+use std::io::{self, Error, Write};
+extern crate rpassword;
+
+use rpassword::read_password;
 
 pub fn get_input(prompt: &str) -> Result<String, Error> {
     println!("{}", prompt);
@@ -8,4 +12,22 @@ pub fn get_input(prompt: &str) -> Result<String, Error> {
         Err(err) => return Err(err),
     };
     Ok(input.trim().to_string())
+}
+
+pub fn prompt_password(prompt: &str) -> String {
+    print!("{}", &prompt);
+    std::io::stdout().flush().unwrap();
+    read_password().unwrap()
+}
+
+/// Encryption salt
+pub fn encryption_salt() -> kdf::Salt {
+    kdf::Salt::default()
+}
+
+/// Derive an encryption key from a password.
+pub fn encryption_key(salt: &kdf::Salt, password: String) -> kdf::SecretKey {
+    kdf::Password::from_slice(password.as_bytes())
+        .and_then(|password| kdf::derive_key(&password, salt, 3, 1 << 16, 32))
+        .expect("Generation of encryption secret key shouldn't fail")
 }

--- a/src/crypto/utils.rs
+++ b/src/crypto/utils.rs
@@ -28,6 +28,6 @@ pub fn encryption_salt() -> kdf::Salt {
 /// Derive an encryption key from a password.
 pub fn encryption_key(salt: &kdf::Salt, password: String) -> kdf::SecretKey {
     kdf::Password::from_slice(password.as_bytes())
-        .and_then(|password| kdf::derive_key(&password, salt, 3, 1 << 16, 32))
+        .and_then(|password| kdf::derive_key(&password, salt, 3, 1 << 17, 32))
         .expect("Generation of encryption secret key shouldn't fail")
 }

--- a/src/crypto/utils.rs
+++ b/src/crypto/utils.rs
@@ -1,24 +1,4 @@
 use orion::kdf;
-use std::io::{self, Error, Write};
-extern crate rpassword;
-
-use rpassword::read_password;
-
-pub fn get_input(prompt: &str) -> Result<String, Error> {
-    println!("{}", prompt);
-    let mut input = String::new();
-    match io::stdin().read_line(&mut input) {
-        Ok(_) => {}
-        Err(err) => return Err(err),
-    };
-    Ok(input.trim().to_string())
-}
-
-pub fn prompt_password(prompt: &str) -> String {
-    print!("{}", &prompt);
-    std::io::stdout().flush().unwrap();
-    read_password().unwrap()
-}
 
 /// Encryption salt
 pub fn encryption_salt() -> kdf::Salt {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
 pub mod cli;
 pub mod crypto;
 pub mod types;
+pub mod utils;
 
 fn main() {
+    // Derive keys from mnemonic:
     // cli::hdkeys::derive();
-    cli::import::import();
+
+    // Export secret key from wallet.toml
+    cli::export::export();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,45 +1,8 @@
+pub mod cli;
 pub mod crypto;
 pub mod types;
 
-use crypto::{keys, mnemonic, utils};
-use types::address;
-use zeroize::Zeroize;
-
-const INPUT_ERROR: &str = "Enountered error obtaining input from user!";
-
 fn main() {
-    let mut phrase = utils::get_input("Enter mnemonic phrase:").expect(INPUT_ERROR);
-    let m = mnemonic::Mnemonic::from_phrase(&phrase);
-    phrase.zeroize();
-
-    match m {
-        Ok(m) => {
-            println!("\nMnemonic is valid, continuing...");
-            let hd_path = utils::get_input("Enter derivation path:").expect(INPUT_ERROR);
-            println!("Using path: {}\n", &hd_path);
-
-            let mut seed = m
-                .to_seed(None)
-                .expect("Conversion to seed bytes should not fail!");
-            let wallet = keys::HDWallet::new(seed.clone()).expect("Could not instantiate wallet!");
-            seed.zeroize();
-
-            let keypair = wallet.derive(hd_path).expect("Invalid path!");
-
-            let mut private_key = keypair.private().to_hex();
-            println!("Private Key: {}", &private_key);
-
-            let address_util = address::Address::new(private_key.clone());
-            private_key.zeroize();
-
-            let public_key = address_util.public();
-            let address = address_util.implicit();
-
-            println!("Address: {}", &address);
-            println!("Public Key: {}", &public_key);
-        }
-        Err(error) => {
-            panic!("\n{}\n", error);
-        }
-    }
+    // cli::hdkeys::derive();
+    cli::import::import();
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,20 @@
+use std::io::{self, Error, Write};
+extern crate rpassword;
+
+use rpassword::read_password;
+
+pub fn get_input(prompt: &str) -> Result<String, Error> {
+    println!("{}", prompt);
+    let mut input = String::new();
+    match io::stdin().read_line(&mut input) {
+        Ok(_) => {}
+        Err(err) => return Err(err),
+    };
+    Ok(input.trim().to_string())
+}
+
+pub fn prompt_password(prompt: &str) -> String {
+    print!("{}", &prompt);
+    std::io::stdout().flush().unwrap();
+    read_password().unwrap()
+}


### PR DESCRIPTION
Adding ability to decode a `wallet.toml` and decrypt any secret, identified by account `alias`. 

- [x] Prompt user for alias (to look up secret)
- [x] If found, and is encrypted, prompt for password to decrypt, then output decrypted secret
- [x] Match encryption algorithm used by CLI
- [x] If unencrypted, simply output value

## TODO

- Prompt user for path to wallet.toml (not super important, would be nice though)
- Confirm exact encrypted method as of Feb 2, 2024 in CLI, and replicate here (though this uses `orion::aead` which I think is correct, I might be missing something - does not work on current wallets)
- Better error handling - if account alias doesn't exist, it panics. Update it to re-prompt for account alias